### PR TITLE
Hotfix v17.0.1: Order line unit price discount handling

### DIFF
--- a/src/Umbraco.Commerce.PaymentProviders.Mollie/MollieOneTimePaymentProviderV2.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Mollie/MollieOneTimePaymentProviderV2.cs
@@ -175,6 +175,8 @@ namespace Umbraco.Commerce.PaymentProviders.Mollie
             // Process order lines
             foreach (OrderLineReadOnly orderLine in ctx.Order.OrderLines)
             {
+                // Use WithoutAdjustments for TotalAmount and VatAmount so that TotalAmount = UnitPrice × Quantity
+                // which is what Mollie validates. The adjustment is handled as a separate discount line below.
                 var molliePaymentLine = new PaymentLine
                 {
                     Sku = orderLine.Sku,
@@ -182,8 +184,8 @@ namespace Umbraco.Commerce.PaymentProviders.Mollie
                     Quantity = (int)orderLine.Quantity,
                     UnitPrice = new MollieAmount(currency.Code, orderLine.UnitPrice.WithoutAdjustments.WithTax),
                     VatRate = (orderLine.TaxRate.Value * 100).ToString("0.00", CultureInfo.InvariantCulture),
-                    VatAmount = new MollieAmount(currency.Code, orderLine.TotalPrice.Value.Tax),
-                    TotalAmount = new MollieAmount(currency.Code, orderLine.TotalPrice.Value.WithTax),
+                    VatAmount = new MollieAmount(currency.Code, orderLine.TotalPrice.WithoutAdjustments.Tax),
+                    TotalAmount = new MollieAmount(currency.Code, orderLine.TotalPrice.WithoutAdjustments.WithTax),
                     Type = !string.IsNullOrWhiteSpace(ctx.Settings.OrderLineProductTypePropertyAlias)
                         ? orderLine.Properties[ctx.Settings.OrderLineProductTypePropertyAlias]
                         : MollieOrderLineType.Physical,

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
This pull request updates the handling of order line amounts in the Mollie payment provider to ensure compliance with Mollie’s validation requirements. It also increments the package version to reflect the change.

Order line calculation fix:

* In `MollieOneTimePaymentProviderV2.cs`, the calculation for `TotalAmount` and `VatAmount` in `PaymentLine` now uses the `WithoutAdjustments` values, ensuring that `TotalAmount = UnitPrice × Quantity` as required by Mollie. This change also clarifies that any adjustments (such as discounts) are handled separately.