### PR TITLE
Refactor Mollie payment line handling for bundles

### DIFF
--- a/src/Umbraco.Commerce.PaymentProviders.Mollie/MollieOneTimePaymentProviderV2.cs
+++ b/src/Umbraco.Commerce.PaymentProviders.Mollie/MollieOneTimePaymentProviderV2.cs
@@ -175,29 +175,75 @@ namespace Umbraco.Commerce.PaymentProviders.Mollie
             // Process order lines
             foreach (OrderLineReadOnly orderLine in ctx.Order.OrderLines)
             {
-                // Use WithoutAdjustments for TotalAmount and VatAmount so that TotalAmount = UnitPrice × Quantity
-                // which is what Mollie validates. The adjustment is handled as a separate discount line below.
-                var molliePaymentLine = new PaymentLine
+                if (orderLine.IsBundle(out BundleOrderLineReadOnly bundleOrderLine) && bundleOrderLine.OrderLines != null && bundleOrderLine.OrderLines.Any())
                 {
-                    Sku = orderLine.Sku,
-                    Description = orderLine.Name,
-                    Quantity = (int)orderLine.Quantity,
-                    UnitPrice = new MollieAmount(currency.Code, orderLine.UnitPrice.WithoutAdjustments.WithTax),
-                    VatRate = (orderLine.TaxRate.Value * 100).ToString("0.00", CultureInfo.InvariantCulture),
-                    VatAmount = new MollieAmount(currency.Code, orderLine.TotalPrice.WithoutAdjustments.Tax),
-                    TotalAmount = new MollieAmount(currency.Code, orderLine.TotalPrice.WithoutAdjustments.WithTax),
-                    Type = !string.IsNullOrWhiteSpace(ctx.Settings.OrderLineProductTypePropertyAlias)
-                        ? orderLine.Properties[ctx.Settings.OrderLineProductTypePropertyAlias]
-                        : MollieOrderLineType.Physical,
-                };
-
-                if (!string.IsNullOrWhiteSpace(ctx.Settings.OrderLineProductCategoryPropertyAlias))
-                {
-                    molliePaymentLine.Categories = orderLine.Properties[ctx.Settings.OrderLineProductCategoryPropertyAlias].Value.Split(',');
+                    // Bundle orderline validation
+                    // Split bundle: parent gets its own amounts, each sub-line becomes a separate Mollie line
+                    var subLineTotalWithTax = bundleOrderLine.OrderLines.Sum(sl => sl.TotalPrice.WithoutAdjustments.WithTax);
+                    var subLineTotalTax = bundleOrderLine.OrderLines.Sum(sl => sl.TotalPrice.WithoutAdjustments.Tax);
+            
+                    var parentOwnWithTax = orderLine.TotalPrice.WithoutAdjustments.WithTax - subLineTotalWithTax;
+                    var parentOwnTax = orderLine.TotalPrice.WithoutAdjustments.Tax - subLineTotalTax;
+            
+                    if (parentOwnWithTax > 0m)
+                    {
+                        molliePaymentLines.Add(new PaymentLine
+                        {
+                            Sku = orderLine.Sku,
+                            Description = orderLine.Name,
+                            Quantity = (int)orderLine.Quantity,
+                            UnitPrice = new MollieAmount(currency.Code, parentOwnWithTax),
+                            VatRate = (orderLine.TaxRate.Value * 100).ToString("0.00", CultureInfo.InvariantCulture),
+                            VatAmount = new MollieAmount(currency.Code, parentOwnTax),
+                            TotalAmount = new MollieAmount(currency.Code, parentOwnWithTax),
+                            Type = !string.IsNullOrWhiteSpace(ctx.Settings.OrderLineProductTypePropertyAlias)
+                                ? orderLine.Properties[ctx.Settings.OrderLineProductTypePropertyAlias]
+                                : MollieOrderLineType.Physical,
+                        });
+                    }
+            
+                    foreach (var subLine in bundleOrderLine.OrderLines)
+                    {
+                        molliePaymentLines.Add(new PaymentLine
+                        {
+                            Sku = subLine.Sku ?? orderLine.Sku,
+                            Description = subLine.Name,
+                            Quantity = (int)subLine.Quantity,
+                            UnitPrice = new MollieAmount(currency.Code, subLine.UnitPrice.WithoutAdjustments.WithTax),
+                            VatRate = (subLine.TaxRate.Value * 100).ToString("0.00", CultureInfo.InvariantCulture),
+                            VatAmount = new MollieAmount(currency.Code, subLine.TotalPrice.WithoutAdjustments.Tax),
+                            TotalAmount = new MollieAmount(currency.Code, subLine.TotalPrice.WithoutAdjustments.WithTax),
+                            Type = MollieOrderLineType.Physical,
+                        });
+                    }
                 }
-
-                molliePaymentLines.Add(molliePaymentLine);
-
+                else
+                {
+                    // Non Bundle orderline validation
+                    // Use WithoutAdjustments for TotalAmount and VatAmount so that TotalAmount = UnitPrice × Quantity
+                    // which is what Mollie validates. The adjustment is handled as a separate discount line below.
+                    var molliePaymentLine = new PaymentLine
+                    {
+                        Sku = orderLine.Sku,
+                        Description = orderLine.Name,
+                        Quantity = (int)orderLine.Quantity,
+                        UnitPrice = new MollieAmount(currency.Code, orderLine.UnitPrice.WithoutAdjustments.WithTax),
+                        VatRate = (orderLine.TaxRate.Value * 100).ToString("0.00", CultureInfo.InvariantCulture),
+                        VatAmount = new MollieAmount(currency.Code, orderLine.TotalPrice.WithoutAdjustments.Tax),
+                        TotalAmount = new MollieAmount(currency.Code, orderLine.TotalPrice.WithoutAdjustments.WithTax),
+                        Type = !string.IsNullOrWhiteSpace(ctx.Settings.OrderLineProductTypePropertyAlias)
+                            ? orderLine.Properties[ctx.Settings.OrderLineProductTypePropertyAlias]
+                            : MollieOrderLineType.Physical,
+                    };
+    
+                    if (!string.IsNullOrWhiteSpace(ctx.Settings.OrderLineProductCategoryPropertyAlias))
+                    {
+                        molliePaymentLine.Categories = orderLine.Properties[ctx.Settings.OrderLineProductCategoryPropertyAlias].Value.Split(',');
+                    }
+    
+                    molliePaymentLines.Add(molliePaymentLine);
+                }
+            
                 // Because an order line can have sub order lines and various discounts and fees
                 // can apply, rather than adding each discount or fee to each order line, we
                 // add a single adjustment to the whole primary order line.


### PR DESCRIPTION
This pull request updates the handling of bundle order lines in the `MollieOneTimePaymentProviderV2` payment provider to ensure correct splitting and validation of bundle items when generating Mollie payment lines. The changes improve accuracy in how bundle and non-bundle order lines are processed and sent to Mollie.

This pull request directly relates to issue: https://github.com/umbraco/Umbraco.Commerce.Issues/issues/836 

### Bundle order line processing improvements

* Added logic to detect bundle order lines using `orderLine.IsBundle`, and split them so that the parent bundle and each sub-line are represented as separate Mollie payment lines with correct amounts and tax calculations.
* For bundle parents, only their "own" amounts (excluding sub-lines) are included as a Mollie line if greater than zero, ensuring no double-counting.
* Each bundle sub-line is added as an individual Mollie payment line, inheriting or overriding relevant values such as SKU, description, and tax rate.

### Non-bundle order line handling

* Retained and clarified the logic for non-bundle order lines, ensuring that amounts and VAT are calculated without adjustments, as required by Mollie validation.
